### PR TITLE
Product Card Improvements Across Profile and Feed Pages

### DIFF
--- a/css/output.css
+++ b/css/output.css
@@ -701,6 +701,10 @@ video {
   top: 0.5rem;
 }
 
+.left-2 {
+  left: 0.5rem;
+}
+
 .z-10 {
   z-index: 10;
 }
@@ -877,6 +881,34 @@ video {
   margin-bottom: 2.5rem;
 }
 
+.mt-auto {
+  margin-top: auto;
+}
+
+.mr-12 {
+  margin-right: 3rem;
+}
+
+.-mb-2 {
+  margin-bottom: -0.5rem;
+}
+
+.-mt-2 {
+  margin-top: -0.5rem;
+}
+
+.-mt-6 {
+  margin-top: -1.5rem;
+}
+
+.-mt-5 {
+  margin-top: -1.25rem;
+}
+
+.-mt-7 {
+  margin-top: -1.75rem;
+}
+
 .block {
   display: block;
 }
@@ -899,6 +931,10 @@ video {
 
 .aspect-\[3\/4\] {
   aspect-ratio: 3/4;
+}
+
+.aspect-\[4\/4\] {
+  aspect-ratio: 4/4;
 }
 
 .h-10 {
@@ -1130,6 +1166,10 @@ video {
   max-width: 20rem;
 }
 
+.max-w-\[280px\] {
+  max-width: 280px;
+}
+
 .shrink {
   flex-shrink: 1;
 }
@@ -1249,6 +1289,10 @@ video {
 
 .gap-1 {
   gap: 0.25rem;
+}
+
+.gap-5 {
+  gap: 1.25rem;
 }
 
 .space-x-6 > :not([hidden]) ~ :not([hidden]) {
@@ -1453,6 +1497,16 @@ video {
 .border-green-600 {
   --tw-border-opacity: 1;
   border-color: rgb(22 163 74 / var(--tw-border-opacity, 1));
+}
+
+.border-gray-200 {
+  --tw-border-opacity: 1;
+  border-color: rgb(229 231 235 / var(--tw-border-opacity, 1));
+}
+
+.border-gray-100 {
+  --tw-border-opacity: 1;
+  border-color: rgb(243 244 246 / var(--tw-border-opacity, 1));
 }
 
 .border-t-button-prime {
@@ -1972,6 +2026,16 @@ video {
   color: rgb(22 163 74 / var(--tw-text-opacity, 1));
 }
 
+.text-gray-500 {
+  --tw-text-opacity: 1;
+  color: rgb(107 114 128 / var(--tw-text-opacity, 1));
+}
+
+.text-gray-700 {
+  --tw-text-opacity: 1;
+  color: rgb(55 65 81 / var(--tw-text-opacity, 1));
+}
+
 .underline {
   text-decoration-line: underline;
 }
@@ -2106,6 +2170,10 @@ video {
   --tw-scale-x: 1.05;
   --tw-scale-y: 1.05;
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.hover\:cursor-pointer:hover {
+  cursor: pointer;
 }
 
 .hover\:border-hover-fourText:hover {
@@ -2315,6 +2383,10 @@ video {
 @media (min-width: 768px) {
   .md\:static {
     position: static;
+  }
+
+  .md\:m-12 {
+    margin: 3rem;
   }
 
   .md\:mx-12 {
@@ -2532,6 +2604,12 @@ video {
 
   .md\:justify-start {
     justify-content: flex-start;
+  }
+
+  .md\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(1rem * var(--tw-space-x-reverse));
+    margin-left: calc(1rem * calc(1 - var(--tw-space-x-reverse)));
   }
 
   .md\:rounded-lg {

--- a/js/feed/feed.js
+++ b/js/feed/feed.js
@@ -14,19 +14,57 @@ let currentSearch = "";
 function createCard(listing) {
   const wrapper = document.createElement("a");
   wrapper.href = `detail-listing.html?id=${listing.id}`;
-  wrapper.className = "shadow-lg hover:shadow-xl transition block bg-white rounded";
+  wrapper.className = "block";
+
+  const card = document.createElement("div");
+  card.className = "shadow-lg flex flex-col items-center aspect-[3/4] p-3 border border-brown-100 hover:shadow-xl transition bg-white hover:scale-105 cursor-pointer rounded-lg group";
+
+  const imageWrapper = document.createElement("div");
+  imageWrapper.className = "relative w-full h-2/3 overflow-hidden group border";
 
   const img = document.createElement("img");
-  img.src = listing.media[0]?.url || "https://placehold.co/400x300?text=No+Image";
-  img.alt = listing.media[0]?.alt || listing.title;
-  img.className = "w-full h-60 object-cover";
+  img.src = listing.media?.[0]?.url || "https://placehold.co/400x300?text=No+Image";
+  img.alt = listing.media?.[0]?.alt || listing.title;
+  img.className = "w-full h-full object-cover transition duration-300 cursor-pointer hover:scale-105 group-hover:scale-105";
+
+  imageWrapper.appendChild(img);
+
+  const infoContainer = document.createElement("div");
+  infoContainer.className = "flex-grow flex flex-col items-center justify-center text-center gap-1";
 
   const title = document.createElement("p");
   title.textContent = listing.title;
-  title.className = "text-center font-serif py-2";
+  title.className = "text-center font-body text-xl font-regular text-brown-900";
 
-  wrapper.appendChild(img);
-  wrapper.appendChild(title);
+
+  const timeLeft = document.createElement("p");
+  const endsAt = new Date(listing.endsAt);
+  const timeDiff = Math.max(endsAt - new Date(), 0); 
+  
+
+  const days = parseInt(timeDiff / (1000 * 60 * 60 * 24)); 
+  const hours = parseInt((timeDiff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)); 
+  const minutes = parseInt((timeDiff % (1000 * 60 * 60)) / (1000 * 60)); 
+
+  const price = listing.bids?.length
+    ? Math.max(...listing.bids.map((b) => b.amount))
+    : 0;
+  const priceText = document.createElement("p");
+  priceText.textContent = `Highest bid: ${price} credits`;
+  priceText.className = "text-sm text-gray-700";
+  if (price === 0) {
+    priceText.textContent = "No bids yet";
+    priceText.className = "text-sm text-brown-700";
+  }
+
+  timeLeft.textContent = `Time left: ${days}d ${hours}h ${minutes}m`;
+  timeLeft.className = "text-sm text-gray-700 mt-2"; 
+
+  infoContainer.appendChild(title);
+  infoContainer.appendChild(timeLeft);
+  infoContainer.appendChild(priceText);
+  card.append(imageWrapper, infoContainer);
+  wrapper.appendChild(card);
 
   return wrapper;
 }

--- a/js/listings.js
+++ b/js/listings.js
@@ -21,13 +21,13 @@ function createCardElement(listing) {
   const img = document.createElement("img");
   img.src = listing.media?.[0]?.url || "https://placehold.co/240x240?text=No+Image";
   img.alt = listing.title;
-  img.className = "w-full h-full object-cover rounded";
+  img.className = "w-full h-full object-cover";
 
   imageBox.appendChild(img);
 
   const content = document.createElement("div");
   content.className =
-    "flex flex-col justify-end items-center text-center px-2 pt-8 pb-4 mt-auto gap-1";
+    "flex flex-col justify-end items-center text-center px-2 pt-8 pb-4 mt-auto w-full";
 
   const title = document.createElement("h3");
   title.className = "text-base font-bold";

--- a/js/profile-js/services/fetchapi.js
+++ b/js/profile-js/services/fetchapi.js
@@ -97,7 +97,7 @@ async function handleProfileUpdate(event) {
 
       setTimeout(() => {
         window.location.reload();
-      }, 2000);
+      }, 1000);
     }
   } else {
     console.error("could not update profile");

--- a/js/profile-js/services/listings_profile.js
+++ b/js/profile-js/services/listings_profile.js
@@ -1,62 +1,72 @@
 import { fetchListing, deleteUserPost, editPost, SeeWinningAuction, yourOwnBids} from "../apiprofile.js"; 
 
-export async function showUserListings(username) {
-    try {
-      const result = await fetchListing(username);
-      const listings = result?.data || [];
-  
-      const productsContainer = document.getElementById("productsContainer");
-      productsContainer.className = "grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6";
-      productsContainer.innerHTML = "";
-  
-      listings.forEach((listing) => {
-        const wrapper = document.createElement("div");
-        wrapper.className = "bg-white border border-gray-300 rounded shadow-lg w-full max-w-[280px] h-[420px] flex flex-col items-center p-4";
-  
-        const imageBox = document.createElement("div");
-        imageBox.className = "w-full h-[250px] flex items-center justify-center bg-white p-2";
-  
-        const img = document.createElement("img");
-        img.src = listing.media?.[0]?.url || "https://placehold.co/240x240?text=No+Image";
-        img.alt = listing.title;
-        img.className = "w-full h-full object-cover rounded";
-        imageBox.appendChild(img);
-  
-        const content = document.createElement("div");
-        content.className = "flex flex-col justify-end items-center text-center px-2 pt-8 pb-4 mt-auto gap-1";
-  
-        const title = document.createElement("h3");
-        title.className = "text-base font-bold";
-        title.textContent = listing.title;
-  
-        const bid = document.createElement("p");
-        bid.className = "text-sm text-gray-700";
-        bid.textContent = listing.bids?.length
-          ? `Highest bid: ${Math.max(...listing.bids.map((b) => b.amount))} credits`
-          : "Highest bid: No bids yet";
-  
-        const time = document.createElement("p");
-        time.className = "text-xs text-gray-500";
-        time.textContent = `Time left: ${Math.max(
-          Math.floor((new Date(listing.endsAt) - new Date()) / 3600000),
-          0
-        )}h`;
-  
-        content.append(title, bid, time);
-        wrapper.appendChild(imageBox);
-        wrapper.appendChild(content);
-        productsContainer.appendChild(wrapper);
-      });
-    } catch (error) {
-      console.error("Error fetching user products:", error.message);
-    }
+export async function showUserListings() {
+  const user = JSON.parse(localStorage.getItem("user"));
+  const username = user?.name;
+
+  if (!username) {
+    console.error("Username not found in localStorage.");
+    return;
   }
+
+  try {
+    const result = await fetchListing(username);
+    const listings = result?.data || [];
+
+    const productsContainer = document.getElementById("productsContainer");
+    productsContainer.className = "grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6";
+    productsContainer.innerHTML = "";
+
+    listings.forEach((product) => {
+      const card = document.createElement("div");
+      card.className = " flex flex-col items-center aspect-[3/4] p-3 border border-brown-100 cursor-pointer";
+
+      const imageWrapper = document.createElement("div");
+      imageWrapper.className = "relative w-full h-2/3 overflow-hidden group";
+
+      const img = document.createElement("img");
+      img.src = product.media?.[0]?.url;
+      img.alt = product.title;
+      img.className = "w-full h-full object-cover transition duration-300 cursor-pointer";
+
+      img.addEventListener("click", () => {
+        window.location.href = `/listings/detail-listing.html?id=${product.id}`;
+      });
+
+      const titleContainer = document.createElement("div");
+      titleContainer.className = "flex-grow flex items-center justify-center";
+
+      const title = document.createElement("p");
+      title.textContent = product.title;
+      title.className = "text-center font-body text-xl font-regular";
+
+      const buttonContainer = document.createElement("div");
+      buttonContainer.className = "flex justify-center gap-1 pb-4";
+
+      const editButton = createEditButton(product);
+      const deleteButton = createDeleteButton(product.id);
+
+      imageWrapper.appendChild(img);
+      titleContainer.appendChild(title);
+      buttonContainer.appendChild(editButton);
+      buttonContainer.appendChild(deleteButton);
+
+      card.appendChild(imageWrapper);
+      card.appendChild(titleContainer);
+      card.appendChild(buttonContainer);
+
+      productsContainer.appendChild(card);
+    });
+  } catch (error) {
+    console.error("Error fetching user products:", error.message);
+  }
+}
   
 
 function createDeleteButton(postId) {
     const deleteButton = document.createElement("button");
     deleteButton.textContent = "Delete";
-    deleteButton.className = "text-black px-4 py-2 rounded hover:bg-gray-300";
+    deleteButton.className = "text-black px-4 py-2 rounded hover:bg-brown-300";
 
     deleteButton.addEventListener("click", async () => {
         const confirmDelete = confirm("Are you sure you want to delete this post?");
@@ -82,7 +92,7 @@ function createDeleteButton(postId) {
 function createEditButton(product) {
     const editButton = document.createElement("button");
     editButton.textContent = "Edit";
-    editButton.className = "text-black px-4 py-2 rounded hover:bg-gray-300";
+    editButton.className = "text-black px-4 py-2 rounded hover:bg-brown-300";
 
     editButton.addEventListener("click", () => {
         document.getElementById("productsContainer").style.display = "none";
@@ -139,7 +149,7 @@ async function submitPostUpdate(postId, newTitle, newDescription, newImageUrl) {
       setTimeout(() => {
         hideEditForm();
         window.location.reload();
-      }, 2000);
+      }, 1000);
     } catch (error) {
       console.error("Error updating post:", error.message);
       alert("Failed to update the post.");
@@ -171,104 +181,111 @@ document.getElementById("edit-auction-form").addEventListener("submit", async fu
 });
 
 export async function displayWinningAuctions() {
-    const container = document.getElementById("winning_bid");
-    container.className = "grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6";
-    container.innerHTML = "";
-  
-    const response = await SeeWinningAuction();
-    const winningAuctions = response?.data || [];
-  
-    if (winningAuctions.length === 0) {
-      container.innerHTML = "<p>You have not won any auctions.</p>";
+  const container = document.getElementById("winning_bid");
+  container.className = "grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6";
+  container.innerHTML = "";
+
+  const response = await SeeWinningAuction();
+  const winningAuctions = response?.data || [];
+
+  winningAuctions.forEach((auction) => {
+    const card = document.createElement("div");
+    card.className = "shadow-lg flex flex-col items-center aspect-[3/4] p-3 border border-brown-100 hover:scale-105 cursor-pointer transition";
+    card.addEventListener("click", () => {
+      window.location.href = `/listings/detail-listing.html?id=${auction.id}`;
+    });
+
+    const imageWrapper = document.createElement("div");
+    imageWrapper.className = "relative w-full h-2/3 overflow-hidden group border";
+
+    const img = document.createElement("img");
+    img.src = auction.media?.[0]?.url || "https://placehold.co/400x300?text=No+Image";
+    img.alt = auction.title;
+    img.className = "w-full h-full object-cover duration-300";
+
+    imageWrapper.appendChild(img);
+
+    const infoContainer = document.createElement("div");
+    infoContainer.className = "flex-grow flex flex-col items-center justify-center text-center gap-1";
+
+    const title = document.createElement("p");
+    title.textContent = auction.title;
+    title.className = "text-center font-body text-xl font-regular";
+
+    const winningText = document.createElement("p");
+    winningText.className = "text-sm text-green-600";
+    winningText.textContent = "Won Auction!";
+
+    const endInfo = document.createElement("p");
+    endInfo.className = "text-xs text-brown-700";
+    endInfo.textContent = `Ended ${new Date(auction.endsAt).toLocaleString()}`;
+
+    infoContainer.append(title, winningText, endInfo);
+
+    card.append(imageWrapper, infoContainer);
+    container.appendChild(card);
+  });
+}
+
+export async function showYourOwnBids() {
+  const container = document.getElementById("active-bids");
+  container.className = "grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6";
+  container.innerText = "";
+
+  try {
+    const response = await yourOwnBids();
+    const ownBids = Array.isArray(response?.data) ? response.data : [];
+
+    if (ownBids.length === 0) {
+      container.innerHTML = "<p>You have not placed any bids.</p>";
       return;
     }
-  
-    winningAuctions.forEach((auction) => {
-      const wrapper = document.createElement("div");
-      wrapper.className = "bg-white border border-gray-300 rounded shadow-lg w-full max-w-[280px] h-[420px] flex flex-col items-center p-4";
-  
-      const imageBox = document.createElement("div");
-      imageBox.className = "w-full h-[250px] flex items-center justify-center bg-white p-2";
-  
-      const img = document.createElement("img");
-      img.src = auction.media?.[0]?.url || "https://placehold.co/240x240?text=No+Image";
-      img.alt = auction.title;
-      img.className = "w-full h-full object-cover rounded";
-      imageBox.appendChild(img);
-  
-      const content = document.createElement("div");
-      content.className = "flex flex-col justify-end items-center text-center px-2 pt-8 pb-4 mt-auto gap-1";
-  
-      const title = document.createElement("h3");
-      title.className = "text-base font-bold";
-      title.textContent = auction.title;
-  
-      const winningBid = document.createElement("p");
-      winningBid.className = "text-sm text-green-600";
-      winningBid.textContent = "Winning bid";
-  
-      const endInfo = document.createElement("p");
-      endInfo.className = "text-xs text-gray-500";
-      endInfo.textContent = `Ended ${new Date(auction.endsAt).toLocaleString()}`;
-  
-      content.append(title, winningBid, endInfo);
-      wrapper.append(imageBox, content);
-      container.appendChild(wrapper);
-    });
-  }
 
-  export async function showYourOwnBids() {
-    const container = document.getElementById("active-bids");
-    container.className = "grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6";
-    container.innerHTML = "";
-  
-    try {
-      const response = await yourOwnBids();
-      const ownBids = Array.isArray(response?.data) ? response.data : [];
-  
-      if (ownBids.length === 0) {
-        container.innerHTML = "<p>You have not placed any bids.</p>";
-        return;
-      }
-  
-      ownBids.forEach((bid) => {
-        const wrapper = document.createElement("div");
-        wrapper.className = "bg-white border border-gray-300 rounded shadow-lg w-full max-w-[280px] h-[420px] flex flex-col items-center p-4 cursor-pointer";
-  
-        const imageBox = document.createElement("div");
-        imageBox.className = "w-full h-[250px] flex items-center justify-center bg-white p-2";
-  
-        const img = document.createElement("img");
-        img.src = bid.listing?.media?.[0]?.url || "https://placehold.co/240x240?text=No+Image";
-        img.alt = bid.listing?.title || "No title";
-        img.className = "w-full h-full object-cover rounded";
-        img.addEventListener("click", () => {
-          window.location.href = `/listings/detail-listing.html?id=${bid.listing?.id}`;
-        });
-  
-        imageBox.appendChild(img);
-  
-        const content = document.createElement("div");
-        content.className = "flex flex-col justify-end items-center text-center px-2 pt-8 pb-4 mt-auto gap-1";
-  
-        const title = document.createElement("h3");
-        title.className = "text-base font-bold";
-        title.textContent = bid.listing?.title || "No title";
-  
-        const bidAmount = document.createElement("p");
-        bidAmount.className = "text-sm text-blue-600";
-        bidAmount.textContent = `Your bid: ${bid.amount}`;
-  
-        const endInfo = document.createElement("p");
-        endInfo.className = "text-xs text-gray-500";
-        endInfo.textContent = `Ends ${new Date(bid.listing?.endsAt).toLocaleString()}`;
-  
-        content.append(title, bidAmount, endInfo);
-        wrapper.append(imageBox, content);
-        container.appendChild(wrapper);
+    ownBids.forEach((bid) => {
+      const card = document.createElement("div");
+      card.className = "shadow-lg flex flex-col items-center aspect-[3/4] p-3 border border-brown-100 hover:scale-105 cursor-pointer";
+      card.addEventListener("click", () => {
+        window.location.href = `/listings/detail-listing.html?id=${bid.listing?.id}`;
       });
-    } catch (error) {
-      console.error("Error fetching your bids:", error.message);
-      container.innerHTML = "<p>There was an error loading your bids. Please try again later.</p>";
-    }
+
+      const imageWrapper = document.createElement("div");
+      imageWrapper.className = "relative w-full h-2/3 overflow-hidden group border";
+
+      const img = document.createElement("img");
+      img.src = bid.listing?.media?.[0]?.url || "https://placehold.co/400x300?text=No+Image";
+      img.alt = bid.listing?.title || "No title";
+      img.className = "w-full h-full object-cover transition duration-300 cursor-pointer";
+
+      imageWrapper.appendChild(img);
+
+      const infoContainer = document.createElement("div");
+      infoContainer.className = "flex-grow flex flex-col items-center justify-center text-center gap-1";
+
+      const title = document.createElement("p");
+      title.textContent = bid.listing?.title || "No title";
+      title.className = "text-center font-body text-xl font-regular";
+
+      const bidAmount = document.createElement("p");
+      bidAmount.className = "text-sm text-blue-600";
+      bidAmount.textContent = `Your bid: ${bid.amount}`;
+
+
+      const endsAt = new Date(bid.listing?.endsAt);
+      const timeDiff = endsAt - new Date(); 
+      const daysLeft = parseInt(timeDiff / (1000 * 60 * 60 * 24)); 
+      const hoursLeft = parseInt((timeDiff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)); 
+
+      const endInfo = document.createElement("p");
+      endInfo.className = "text-sm text-body";
+      endInfo.textContent = `Ends in: ${daysLeft} days and ${hoursLeft} hours`;
+
+      infoContainer.append(title, bidAmount, endInfo);
+
+      card.append(imageWrapper, infoContainer);
+      container.appendChild(card);
+    });
+  } catch (error) {
+    console.error("Error fetching your bids:", error.message);
+    container.innerHTML = "<p>There was an error loading your bids. Please try again later.</p>";
   }
+}

--- a/listings/detail-listing.html
+++ b/listings/detail-listing.html
@@ -12,8 +12,8 @@
     <header class="relative w-full border-b border-[#514439]/40 px-6 py-4 grid grid-cols-3 items-center font-inter text-[15px] font-semibold text-brown">
       <!-- Venstre -->
       <div class="hidden md:flex space-x-6 justify-start">
-        <a href="./index.html" class="hover:underline">HOME</a>
-        <a href="./listings/feed.html" class="hover:underline">FEED</a>
+        <a href="../index.html" class="hover:underline">HOME</a>
+        <a href="../listings/feed.html" class="hover:underline">FEED</a>
       </div>
     
       <!-- Midten -->
@@ -38,8 +38,8 @@
     
     <nav id="mobile-menu"
       class="md:hidden hidden flex flex-col gap-3 bg-white px-6 py-6 border-t border-brown shadow-md text-[15px] font-black tracking-wide uppercase text-brown font-inter animate-fade-in">
-      <a href="./index.html" class="hover:text-button-prime border-b pb-2">HOME</a>
-      <a href="./listings/feed.html" class="hover:text-button-prime border-b pb-2">FEED</a>
+      <a href="../index.html" class="hover:text-button-prime border-b pb-2">HOME</a>
+      <a href="../listings/feed.html" class="hover:text-button-prime border-b pb-2">FEED</a>
       <div id="mobile-user-links" class="flex flex-col gap-3">
         <!-- Fylles med JS -->
       </div>

--- a/listings/feed.html
+++ b/listings/feed.html
@@ -15,7 +15,7 @@
     <!-- Venstre -->
     <div class="hidden md:flex space-x-6 justify-start">
       <a href="../index.html" class="hover:underline">HOME</a>
-      <a href="../listings/feed.html" class="hover:underline">FEED</a>
+      <a href="./feed.html" class="hover:underline">FEED</a>
     </div>
   
     <!-- Midten -->
@@ -40,7 +40,7 @@
   
   <nav id="mobile-menu"
     class="md:hidden hidden flex flex-col gap-3 bg-white px-6 py-6 border-t border-brown shadow-md text-[15px] font-black tracking-wide uppercase text-brown font-inter animate-fade-in">
-    <a href="./index.html" class="hover:text-button-prime border-b pb-2">HOME</a>
+    <a href="../index.html" class="hover:text-button-prime border-b pb-2">HOME</a>
     <a href="./listings/feed.html" class="hover:text-button-prime border-b pb-2">FEED</a>
     <div id="mobile-user-links" class="flex flex-col gap-3">
       <!-- Fylles med JS -->

--- a/profile/index.html
+++ b/profile/index.html
@@ -47,8 +47,8 @@
   
   <nav id="mobile-menu"
     class="md:hidden hidden flex flex-col gap-3 bg-white px-6 py-6 border-t border-brown shadow-md text-[15px] font-black tracking-wide uppercase text-brown font-inter animate-fade-in">
-    <a href="./index.html" class="hover:text-button-prime border-b pb-2">HOME</a>
-    <a href="./listings/feed.html" class="hover:text-button-prime border-b pb-2">FEED</a>
+    <a href="../index.html" class="hover:text-button-prime border-b pb-2">HOME</a>
+    <a href="../listings/feed.html" class="hover:text-button-prime border-b pb-2">FEED</a>
     <div id="mobile-user-links" class="flex flex-col gap-3">
       <!-- Fylles med JS -->
     </div>
@@ -77,7 +77,7 @@
       </div>
     </div>
 <section>
-  <div class="flex justify-center mt-4 space-x-0.5">
+  <div class="flex justify-center mt-4 space-x-0.5 mr-2 ml-2"> 
     <button id="active-auctions-btn" class="btn btn-four">Active Auctions</button>
     <button id="won-auctions-btn" class="btn btn-four">Won Auctions</button>
     <button id="active-bids-btn" class="btn btn-four">Bid history</button>
@@ -141,7 +141,7 @@
       </div>
     </section>
 
-    <section class="mb-12 mt-12 mr-4 ml-4" id="active-auctions">
+    <section class="m-4 md:m-12" id="active-auctions">
       <div class="px-6 py-4 flex justify-center md:justify-start">
         <h3 class="text-lg text-black border-b font-thin">Your Auctions</h3>
 
@@ -152,8 +152,11 @@
     <section id="edit-form" class="bg-brown bg-opacity-50 p-6 rounded-lg shadow-md mt-4 mb-10 hidden">
 
       <h3 class="text-lg font-bold text-white mb-4">Edit Auction</h3>
-      <div id="edit-success" class="hidden bg-green-100 text-green-800 p-4 rounded-md mt-4">
-        <p>Auction updated successfully!</p>
+      <div id="edit-success" class=" hidden flex justify-center bg-green-100 text-green-800 p-4 rounded-md mt-4 w-full max-w-xs mx-auto">
+        <svg class="w-6 h-6 shrink-0 text-green-600" fill="currentColor" viewBox="0 0 20 20">
+          <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-11V5a1 1 0 10-2 0v2a1 1 0 002 0zm0 6v-4a1 1 0 10-2 0v4a1 1 0 002 0z" clip-rule="evenodd" />
+        </svg>
+        <p>Auction created successfully!</p>
       </div>
 
       <form id="edit-auction-form">


### PR DESCRIPTION
I’ve updated the product cards on both the Profile and Feed pages to improve clarity, usability, and consistency across devices.

## Feed Page
- Each product card now has a **brown border** to make it stand out from the background.
- Cards include: **image, title, time remaining, and highest bid**.
- On hover, the card **slightly pops out** to give visual feedback.

## Profile Page
- Product cards created by the user now include a **brown border** for contrast.
- Each card displays the **title**, along with **Edit** and **Delete** buttons.
- On hover, the card **pops out** for better interactivity.

## Winning Bids Section
- Cards are **clickable**, leading to the listing’s detail page.
- Updated the “Winning” text and styled it in **green** to emphasize success.
- Added **hover effect** with pop-out animation and **cursor pointer** for better UX.

## Bid History Section
- Cards now have a **brown border** to separate them from the background.
- Each card includes the **listing image, title, user's bid**, and **auction end time**.
- Cards are **clickable**, navigating to the detail page.
- Hovering makes the card **pop out slightly** for feedback.

## Mobile Header
- Fixed the **hamburger menu** on mobile.
- Clicking **\"Home\"** now correctly navigates to the **main page**.
- On the detail page, clicking **\"Feed\"** now routes correctly to the **feed page**.